### PR TITLE
fix PROJECTS_DIR variable in sample config

### DIFF
--- a/reggae.conf.sample
+++ b/reggae.conf.sample
@@ -8,4 +8,4 @@
 # INTERFACE_IP="172.16.0.254"
 # JAIL_INTERFACE_IP="10.0.0.254"
 # ZFS_POOL="zroot"
-# PROJECT_DIR="/home/user/reggae/repos"
+# PROJECTS_DIR="/home/user/reggae/repos"


### PR DESCRIPTION
latest scripts/network-init.sh want PROJECTS_DIR, not PROJECT_DIR:
PROJECTS_DIR must be set in /usr/local/etc/reggae.conf